### PR TITLE
Use delay from lock-in phase start.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 /.vs
 /Leauge Auto Accept/obj
+/Leauge Auto Accept/bin/Debug/net7.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/.vs
+/Leauge Auto Accept/obj

--- a/Leauge Auto Accept/MainLogic.cs
+++ b/Leauge Auto Accept/MainLogic.cs
@@ -379,7 +379,12 @@ namespace Leauge_Auto_Accept
             string timer = currentChampSelect[1].Split("totalTimeInPhase\":")[1].Split("}")[0];
             long timerInt = Convert.ToInt64(timer);
             long currentTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
-            if (currentTime >= lastActStartTime + timerInt - Settings.lockDelay)
+
+            // Action Times
+            long endOfPhaseTime = currentTime + timerInt;
+            long nextActionTime = lastActStartTime + Settings.lockDelay;
+
+            if (currentTime >= nextActionTime)
             {
                 lockChampion(actId, championId, actType);
             }

--- a/Update.bat
+++ b/Update.bat
@@ -1,0 +1,7 @@
+git fetch
+git pull origin main
+
+cd "Leauge Auto Accept"
+dotnet restore
+
+PAUSE;


### PR DESCRIPTION
The lock-in delay now counts from the beginning of the phase rather than backwards from the end of the phase. 