### PR TITLE
Fixed a bug allowing the cursor escape the grid when holding the leff key

### DIFF
--- a/Leauge Auto Accept/Navigation.cs
+++ b/Leauge Auto Accept/Navigation.cs
@@ -191,8 +191,9 @@ namespace Leauge_Auto_Accept
                     return true;
 
                 case ConsoleKey.LeftArrow:
-                    if (currentPos == 0)
+                    if (currentPos <= 0)
                     {
+                        currentPos = 0;
                         return false;
                     }
                     currentPos -= UI.totalRows;


### PR DESCRIPTION
## Description
Step 1: Enter champion select screen
Step 2: Move cursor to the right
Step 3: Hold the left key

And then, the `currentPos` is less than zero. That make the cursor disapear.

## How Has This Been Tested?
Tested on Windows 11.