### PR TITLE
Start application using conhost (Windows Terminal do not support resize)

### DIFF
--- a/Leauge Auto Accept/ParentProcessUtilities.cs
+++ b/Leauge Auto Accept/ParentProcessUtilities.cs
@@ -1,0 +1,67 @@
+﻿using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using System;
+
+/// <summary>
+/// A utility class to determine a process parent.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct ParentProcessUtilities
+{
+    // These members must match PROCESS_BASIC_INFORMATION
+    internal IntPtr Reserved1;
+    internal IntPtr PebBaseAddress;
+    internal IntPtr Reserved2_0;
+    internal IntPtr Reserved2_1;
+    internal IntPtr UniqueProcessId;
+    internal IntPtr InheritedFromUniqueProcessId;
+
+    [DllImport("ntdll.dll")]
+    private static extern int NtQueryInformationProcess(IntPtr processHandle, int processInformationClass, ref ParentProcessUtilities processInformation, int processInformationLength, out int returnLength);
+
+    /// <summary>
+    /// Gets the parent process of the current process.
+    /// </summary>
+    /// <returns>An instance of the Process class.</returns>
+    public static Process GetParentProcess()
+    {
+        return GetParentProcess(Process.GetCurrentProcess().Handle);
+    }
+
+    /// <summary>
+    /// Gets the parent process of specified process.
+    /// </summary>
+    /// <param name="id">The process id.</param>
+    /// <returns>An instance of the Process class.</returns>
+    public static Process GetParentProcess(int id)
+    {
+        Process process = Process.GetProcessById(id);
+        return GetParentProcess(process.Handle);
+    }
+
+    /// <summary>
+    /// Gets the parent process of a specified process.
+    /// </summary>
+    /// <param name="handle">The process handle.</param>
+    /// <returns>An instance of the Process class.</returns>
+    public static Process GetParentProcess(IntPtr handle)
+    {
+        ParentProcessUtilities pbi = new ParentProcessUtilities();
+        int returnLength;
+        int status = NtQueryInformationProcess(handle, 0, ref pbi, Marshal.SizeOf(pbi), out returnLength);
+        if (status != 0)
+            throw new Win32Exception(status);
+
+        try
+        {
+            return Process.GetProcessById(pbi.InheritedFromUniqueProcessId.ToInt32());
+        }
+        catch (ArgumentException)
+        {
+            // not found
+            return null;
+        }
+    }
+}

--- a/Leauge Auto Accept/Program.cs
+++ b/Leauge Auto Accept/Program.cs
@@ -18,6 +18,21 @@ namespace Leauge_Auto_Accept
     {
         private static void Main()
         {
+            // Start application using conhost (Windows Terminal do not support resize)
+            // Ref: https://github.com/microsoft/terminal/issues/5094
+            var parentProc = ParentProcessUtilities.GetParentProcess();
+            var isDebug = Debugger.IsAttached;
+            if (!isDebug && parentProc.ProcessName != "conhost")
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "conhost",
+                    WorkingDirectory = Directory.GetCurrentDirectory(),
+                    Arguments = Process.GetCurrentProcess().MainModule.FileName,
+                });
+                return;
+            }
+
             // Show initializing message
             UI.initializingWindow();
 


### PR DESCRIPTION
## Description
Seem like Windows Terminal still not support resize after 4 years.
Referer: https://github.com/microsoft/terminal/issues/5094

So, when starting the program, I'll check if it's running through conhost. If not, then it will run itself through conhost and exit.
This is a temporary solution until MS such finds a permanent fix for the issue. It could be 10 years from now.
