### PR TITLE
wmic no longer exists on some Windows 11 machines. Changed it.

### DIFF
--- a/Leauge Auto Accept/Leauge Auto Accept.csproj
+++ b/Leauge Auto Accept/Leauge Auto Accept.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <Content Include="icon.ico" />
+    <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I am no expert but:

1. Depreciated status of wmic means I cannot run the app.
2. After this edit, now it works.

So, I hope it helps.