### PR TITLE
updated v3.7

### DIFF
--- a/Leauge Auto Accept/Data.cs
+++ b/Leauge Auto Accept/Data.cs
@@ -32,7 +32,7 @@ namespace Leauge_Auto_Accept
         public static long currentSummonerId = 0;
         public static string currentChatId = "";
 
-        public static void loadSummonerId()
+        public static bool loadSummonerId()
         {
             Log.Debug("currentSummonerId={0}", currentSummonerId);
             if (currentSummonerId == 0)
@@ -41,18 +41,30 @@ namespace Leauge_Auto_Accept
                 Print.printCentered("Getting summoner ID...", 15);
                 var currentSummoner = LCU.clientRequestUntilSuccess<LCUTypes.LolSummonerV1CurrentSummoner>("GET", "lol-summoner/v1/current-summoner");
                 Console.Clear();
+                if (!currentSummoner.IsSuccessStatusCode || currentSummoner.Data == null)
+                {
+                    Log.Warn("Failed to load summoner id. statusCode={0} responseStatus={1}", currentSummoner.StatusCode, currentSummoner.ResponseStatus);
+                    return false;
+                }
                 currentSummonerId = currentSummoner.Data.SummonerId;
             }
+            return true;
         }
 
-        public static void loadPlayerChatId()
+        public static bool loadPlayerChatId()
         {
             var chatProfileResp = LCU.clientRequest<LCUTypes.LolChatMeV1>("GET", "lol-chat/v1/me");
+            if (!chatProfileResp.IsSuccessStatusCode || chatProfileResp.Data == null)
+            {
+                Log.Warn("Failed to load player chat id. statusCode={0} responseStatus={1}", chatProfileResp.StatusCode, chatProfileResp.ResponseStatus);
+                return false;
+            }
             currentChatId = chatProfileResp.Data.Id;
             currentSummonerId = chatProfileResp.Data.SummonerId;
+            return true;
         }
 
-        public static void loadChampionsList()
+        public static bool loadChampionsList()
         {
             Console.Clear();
 
@@ -60,13 +72,22 @@ namespace Leauge_Auto_Accept
             if (!champsSorted.Any())
             {
                 Log.Info("Loading available champions list from service");
-                loadSummonerId();
+                if (!loadSummonerId())
+                {
+                    Console.Clear();
+                    return false;
+                }
 
                 List<itemList> champs = new List<itemList>();
 
                 Print.printCentered("Getting champions and ownership list...", 15);
                 var ownedChampsResp = LCU.clientRequestUntilSuccess<LCUTypes.LolChampionsInventoriesChampionsMinimalV1[]>("GET", $"lol-champions/v1/inventories/{currentSummonerId}/champions-minimal");
                 Console.Clear();
+                if (!ownedChampsResp.IsSuccessStatusCode || ownedChampsResp.Data == null)
+                {
+                    Log.Warn("Failed to load champions list. statusCode={0} responseStatus={1}", ownedChampsResp.StatusCode, ownedChampsResp.ResponseStatus);
+                    return false;
+                }
 
                 champs = ownedChampsResp.Data
                     .Where(x => x.Name != "None")
@@ -82,22 +103,32 @@ namespace Leauge_Auto_Accept
 
             SizeHandler.resizeBasedOnChampsCount();
             Console.Clear();
+            return true;
         }
 
-        public static void loadRunesList()
+        public static bool loadRunesList()
         {
             Console.Clear();
 
             Log.Debug("runesList.Count={0}", runesList?.Count);
             if (!runesList.Any())
             {
-                loadSummonerId();
+                if (!loadSummonerId())
+                {
+                    Console.Clear();
+                    return false;
+                }
 
                 List<itemList> list = new List<itemList>();
 
                 Print.printCentered("Getting runes list...", 15);
                 var runesResp = LCU.clientRequestUntilSuccess<LCUTypes.LolPerksPagesV1[]>("GET", "lol-perks/v1/pages");
                 Console.Clear();
+                if (!runesResp.IsSuccessStatusCode || runesResp.Data == null)
+                {
+                    Log.Warn("Failed to load runes list. statusCode={0} responseStatus={1}", runesResp.StatusCode, runesResp.ResponseStatus);
+                    return false;
+                }
 
                 runesList = runesResp.Data
                     .Where(x => x.IsValid == true)
@@ -106,9 +137,10 @@ namespace Leauge_Auto_Accept
             }
 
             Console.Clear();
+            return true;
         }
 
-        public static void loadSpellsList()
+        public static bool loadSpellsList()
         {
             Console.Clear();
 
@@ -118,6 +150,11 @@ namespace Leauge_Auto_Accept
                 Print.printCentered("Getting a list of available summoner spells...", 15);
                 var spellsResp = LCU.clientRequest<JsonArray>("GET", "lol-game-data/assets/v1/summoner-spells.json");
                 Console.Clear();
+                if (!spellsResp.IsSuccessStatusCode || spellsResp.Data == null)
+                {
+                    Log.Warn("Failed to load spells list. statusCode={0} responseStatus={1}", spellsResp.StatusCode, spellsResp.ResponseStatus);
+                    return false;
+                }
 
                 // Add to list with names and available gamemodes
                 var spellsTmp = new List<spellList>(20);
@@ -160,6 +197,7 @@ namespace Leauge_Auto_Accept
                 }
                 spellsSorted = spellsTmp;
             }
+            return true;
         }
     }
 }

--- a/Leauge Auto Accept/LCU.cs
+++ b/Leauge Auto Accept/LCU.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Text.Json;
 using RestSharp;
 using System.Collections.Generic;
-using System.Text.Json.Nodes;
 
 namespace Leauge_Auto_Accept
 {
@@ -20,6 +19,8 @@ namespace Leauge_Auto_Accept
 
         private static string[] leagueAuth;
         private static int lcuPid = 0;
+        private const int RequestTimeoutMilliseconds = 5000;
+        private const int MaxRetryAttempts = 5;
         public static bool isLeagueOpen = false;
 
         public static void CheckIfLeagueClientIsOpenTask()
@@ -36,6 +37,15 @@ namespace Leauge_Auto_Accept
 
                         //get token and port
                         leagueAuth = getLeagueAuth(client);
+                        if (leagueAuth == null)
+                        {
+                            isLeagueOpen = false;
+                            MainLogic.isAutoAcceptOn = false;
+                            Log.Warn("League client was found, but LCU auth data could not be read.");
+                            UI.leagueClientIsClosedMessage();
+                            Thread.Sleep(2000);
+                            continue;
+                        }
 
                         //reset restclient
                         S_restClient?.Dispose(); S_restClient = null;
@@ -43,8 +53,15 @@ namespace Leauge_Auto_Accept
                         // Check if preload data was enabled last time
                         if (Settings.preloadData)
                         {
-                            Data.loadChampionsList();
-                            Data.loadSpellsList();
+                            bool championsLoaded = Data.loadChampionsList();
+                            bool spellsLoaded = Data.loadSpellsList();
+                            if (!championsLoaded || !spellsLoaded)
+                            {
+                                Console.Clear();
+                                Print.printCentered("Some League data failed to load.", SizeHandler.HeightCenter - 1);
+                                Print.printCentered("The app will keep running; try opening the selector again.");
+                                Thread.Sleep(2500);
+                            }
                         }
                         if (Settings.shouldAutoAcceptbeOn)
                         {
@@ -102,8 +119,16 @@ namespace Leauge_Auto_Accept
             }
 
             // Parse the port and auth token into variables
-            string port = Regex.Match(commandLine, @"--app-port=""?(\d+)""?").Groups[1].Value;
-            string authToken = Regex.Match(commandLine, @"--remoting-auth-token=([a-zA-Z0-9_-]+)").Groups[1].Value;
+            var portMatch = Regex.Match(commandLine ?? "", @"--app-port=""?(\d+)""?");
+            var authTokenMatch = Regex.Match(commandLine ?? "", @"--remoting-auth-token=([a-zA-Z0-9_-]+)");
+            if (!portMatch.Success || !authTokenMatch.Success)
+            {
+                Log.Warn("Failed to parse LCU auth data. portFound={0} tokenFound={1}", portMatch.Success, authTokenMatch.Success);
+                return null;
+            }
+
+            string port = portMatch.Groups[1].Value;
+            string authToken = authTokenMatch.Groups[1].Value;
 
             // Compute the encoded key
             string auth = "riot:" + authToken;
@@ -143,29 +168,35 @@ namespace Leauge_Auto_Accept
         }
 
         public static RestResponse clientRequest(RestRequest req)
-        { 
-            if (S_restClient == null)
+        {
+            if (!EnsureClient())
             {
-                S_restClient = new RestClient(c => {
-                    c.BaseUrl = new Uri("https://127.0.0.1:" + leagueAuth[1] + "/");
-                    //c.Authenticator = new HttpBasicAuthenticator(leagueAuth[0], "");
-
-                    //disable ssl checks
-                    c.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicy) => true;
-
-                }, h => {
-                    h.Authorization = new AuthenticationHeaderValue("Basic", leagueAuth[0]);
-                });
+                return new RestResponse(req);
             }
 
             Log.Debug("Initiating request {0} {1}", req.Method, req.Resource);
 
             //execute request
-            RestResponse restResp = S_restClient.Execute(req);
+            RestResponse restResp;
+            try
+            {
+                req.Timeout = TimeSpan.FromMilliseconds(RequestTimeoutMilliseconds);
+                restResp = S_restClient.Execute(req);
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(ex, "LCU request failed before response: {0} {1}", req.Method, req.Resource);
+                return new RestResponse(req)
+                {
+                    ErrorException = ex,
+                    ErrorMessage = ex.Message,
+                    ResponseStatus = ResponseStatus.Error
+                };
+            }
 
             if (Log.IsDebugEnabled)
             {
-                 Log.Debug("statusCode={0}, isSuccessful={1}", restResp?.StatusCode, restResp?.IsSuccessful);
+                 Log.Debug("statusCode={0}, responseStatus={1}, isSuccessful={2}", restResp?.StatusCode, restResp?.ResponseStatus, restResp?.IsSuccessful);
             }
 
             WriteToJsonLog(req, restResp);
@@ -178,6 +209,7 @@ namespace Leauge_Auto_Accept
         public static RestResponse clientRequestUntilSuccess(string method, string url, string body = null)
         {
             RestResponse request;
+            int attempts = 0;
             do
             {
                 request = clientRequest(method, url, body);
@@ -187,16 +219,19 @@ namespace Leauge_Auto_Accept
                 }
                 else
                 {
-                    if (CheckIfLeagueClientIsOpen())
+                    attempts++;
+                    if (attempts < MaxRetryAttempts && CheckIfLeagueClientIsOpen())
                     {
                         Thread.Sleep(1000);
                     }
                     else
                     {
+                        Log.Warn("LCU request did not succeed after {0} attempts: {1} {2} statusCode={3} responseStatus={4}",
+                            attempts, method, url, request?.StatusCode, request?.ResponseStatus);
                         return request;
                     }
                 }
-            } while (request.IsSuccessStatusCode == false);
+            } while (request.IsSuccessStatusCode == false && attempts < MaxRetryAttempts);
 
             return request;
         }
@@ -229,33 +264,38 @@ namespace Leauge_Auto_Accept
         }
 
         public static RestResponse<TResponse> clientRequest<TResponse>(RestRequest req)
-        { 
-            if (S_restClient == null)
+        {
+            if (!EnsureClient())
             {
-                S_restClient = new RestClient(c => {
-                    c.BaseUrl = new Uri("https://127.0.0.1:" + leagueAuth[1] + "/");
-                    //c.Authenticator = new HttpBasicAuthenticator(leagueAuth[0], "");
-
-                    //disable ssl checks
-                    c.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicy) => true;
-
-                }, h => {
-                    h.Authorization = new AuthenticationHeaderValue("Basic", leagueAuth[0]);
-                });
+                return new RestResponse<TResponse>(req);
             }
 
             Log.Debug("Initiating request {0} {1}", req.Method, req.Resource);
 
+            RestResponse<TResponse> restResp;
+            try
+            {
+                req.Timeout = TimeSpan.FromMilliseconds(RequestTimeoutMilliseconds);
+                restResp = S_restClient.Execute<TResponse>(req);
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(ex, "LCU request failed before response: {0} {1}", req.Method, req.Resource);
+                return new RestResponse<TResponse>(req)
+                {
+                    ErrorException = ex,
+                    ErrorMessage = ex.Message,
+                    ResponseStatus = ResponseStatus.Error
+                };
+            }
 
-            var restResp = S_restClient.Execute<TResponse>(req);
-            
 
             if (Log.IsDebugEnabled)
             {
-                Log.Debug("statusCode={0}, isSuccessful={1}", restResp.StatusCode, restResp.IsSuccessful);
+                Log.Debug("statusCode={0}, responseStatus={1}, isSuccessful={2}", restResp.StatusCode, restResp.ResponseStatus, restResp.IsSuccessful);
                 if (restResp.IsSuccessful==false)
                 {
-                    Log.Debug("statusDescription={0}, content=\n{1}", restResp.StatusDescription, restResp.Content);
+                    Log.Debug("statusDescription={0}, errorMessage={1}", restResp.StatusDescription, restResp.ErrorMessage);
                 }
             }
 
@@ -267,27 +307,57 @@ namespace Leauge_Auto_Accept
         public static RestResponse<TResponse> clientRequestUntilSuccess<TResponse>(string method, string url, string body = null)
         {
             RestResponse<TResponse> request;
+            int attempts = 0;
             do
             {
                 request = clientRequest<TResponse>(method, url, body);
-                if (request.IsSuccessStatusCode == true)
+                if (request.IsSuccessStatusCode == true && request.Data != null)
                 {
                     return request;
                 }
                 else
                 {
-                    if (CheckIfLeagueClientIsOpen())
+                    attempts++;
+                    if (attempts < MaxRetryAttempts && CheckIfLeagueClientIsOpen())
                     {
                         Thread.Sleep(1000);
                     }
                     else
                     {
+                        Log.Warn("LCU typed request did not succeed after {0} attempts: {1} {2} statusCode={3} responseStatus={4} hasData={5}",
+                            attempts, method, url, request?.StatusCode, request?.ResponseStatus, request != null && request.Data != null);
                         return request;
                     }
                 }
-            } while (request.IsSuccessStatusCode == false);
+            } while ((!request.IsSuccessStatusCode || request.Data == null) && attempts < MaxRetryAttempts);
 
             return request;
+        }
+
+        private static bool EnsureClient()
+        {
+            if (S_restClient != null)
+            {
+                return true;
+            }
+
+            if (leagueAuth == null || leagueAuth.Length < 2 || string.IsNullOrWhiteSpace(leagueAuth[0]) || string.IsNullOrWhiteSpace(leagueAuth[1]))
+            {
+                Log.Warn("LCU client cannot be created because auth data is missing.");
+                return false;
+            }
+
+            S_restClient = new RestClient(c => {
+                c.BaseUrl = new Uri("https://127.0.0.1:" + leagueAuth[1] + "/");
+
+                //disable ssl checks for the local self-signed LCU certificate
+                c.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicy) => true;
+
+            }, h => {
+                h.Authorization = new AuthenticationHeaderValue("Basic", leagueAuth[0]);
+            });
+
+            return true;
         }
 
         private static void WriteToJsonLog(RestRequest request, RestResponse restResp)

--- a/Leauge Auto Accept/Leauge Auto Accept.csproj
+++ b/Leauge Auto Accept/Leauge Auto Accept.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Leauge_Auto_Accept</RootNamespace>
-    <Version>3.6</Version>
+    <Version>3.7</Version>
     <Company />
     <Product />
     <Authors>Artem</Authors>

--- a/Leauge Auto Accept/MainLogic.cs
+++ b/Leauge Auto Accept/MainLogic.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 
 namespace Leauge_Auto_Accept
@@ -42,7 +44,7 @@ namespace Leauge_Auto_Accept
                 {
                     var gameSessionResp = LCU.clientRequest<LCUTypes.LolGameflowSessionV1>("GET", "lol-gameflow/v1/session");
 
-                    if (gameSessionResp.IsSuccessful)
+                    if (gameSessionResp.IsSuccessful && gameSessionResp.Data != null)
                     {
                         var gameSession = gameSessionResp.Data;
 
@@ -66,7 +68,7 @@ namespace Leauge_Auto_Accept
                                 handleMatchmakingAccept();
                                 break;
                             case "ChampSelect":
-                                var gameMode = gameSessionResp.Data.GameData.Queue.GameMode;
+                                var gameMode = gameSessionResp.Data.GameData?.Queue?.GameMode ?? "";
                                 //Console.WriteLine(gameMode);
                                 //Console.ReadLine();
                                 handleChampSelect(gameMode);
@@ -172,10 +174,10 @@ namespace Leauge_Auto_Accept
             // Get data for the current ongoing champ select
             var currentChampSelect = LCU.clientRequest<LCUTypes.LolChampSelectSessionV1>("GET", "lol-champ-select/v1/session");
 
-            if (currentChampSelect.IsSuccessStatusCode)
+            if (currentChampSelect.IsSuccessStatusCode && currentChampSelect.Data != null)
             {
                 // Get needed data from the current champ select 
-                string currentChatRoom = currentChampSelect.Data.ChatDetails.MultiUserChatId;
+                string currentChatRoom = currentChampSelect.Data.ChatDetails?.MultiUserChatId ?? "";
                 if (lastChatRoom != currentChatRoom || lastChatRoom == "")
                 {
                     // Reset stuff in case someone dodged the champ select
@@ -245,15 +247,14 @@ namespace Leauge_Auto_Accept
                         var arenaCrowdFavorites = LCU.clientRequest("GET", "lol-lobby-team-builder/champ-select/v1/crowd-favorte-champion-list");
                         if (arenaCrowdFavorites.IsSuccessStatusCode)
                         {
-                            string arenaCrowdFavoritesData = arenaCrowdFavorites.Content.Replace("[", "").Replace("]", "").Replace("\n", "").Replace(" ", "");
-                            string[] arenaCrowdFavoritesSplit = arenaCrowdFavoritesData.Split(',');
+                            var arenaCrowdFavoritesData = JsonNode.Parse(arenaCrowdFavorites.Content)?.AsArray();
 
                             // Might be less than 5 champs if the player doesn't own that many champs
-                            if (arenaCrowdFavoritesSplit.Length > 0) crowdFavorite1ChampId = arenaCrowdFavoritesSplit[0];
-                            if (arenaCrowdFavoritesSplit.Length > 1) crowdFavorite2ChampId = arenaCrowdFavoritesSplit[1];
-                            if (arenaCrowdFavoritesSplit.Length > 2) crowdFavorite3ChampId = arenaCrowdFavoritesSplit[2];
-                            if (arenaCrowdFavoritesSplit.Length > 3) crowdFavorite4ChampId = arenaCrowdFavoritesSplit[3];
-                            if (arenaCrowdFavoritesSplit.Length > 4) crowdFavorite5ChampId = arenaCrowdFavoritesSplit[4];
+                            if (arenaCrowdFavoritesData?.Count > 0) crowdFavorite1ChampId = arenaCrowdFavoritesData[0]?.ToString() ?? "";
+                            if (arenaCrowdFavoritesData?.Count > 1) crowdFavorite2ChampId = arenaCrowdFavoritesData[1]?.ToString() ?? "";
+                            if (arenaCrowdFavoritesData?.Count > 2) crowdFavorite3ChampId = arenaCrowdFavoritesData[2]?.ToString() ?? "";
+                            if (arenaCrowdFavoritesData?.Count > 3) crowdFavorite4ChampId = arenaCrowdFavoritesData[3]?.ToString() ?? "";
+                            if (arenaCrowdFavoritesData?.Count > 4) crowdFavorite5ChampId = arenaCrowdFavoritesData[4]?.ToString() ?? "";
                         }
                     }
                     
@@ -273,13 +274,12 @@ namespace Leauge_Auto_Accept
                     }
                     else
                     {
-                        var spell = Data.spellsSorted
-                            .First(s => s.id == Settings.currentSpell1[1]);
+                        var spell = Data.spellsSorted.FirstOrDefault(s => s.id == Settings.currentSpell1[1]);
 
-                        if (!spell.gameModes.Contains(gameMode))
+                        if (spell == null || !spell.gameModes.Contains(gameMode))
                         {
                             pickedSpell1 = true;
-                            Log.Debug("Spell 1 no available for current gamemode, skipping");
+                            Log.Debug("Spell 1 not available for current gamemode or not loaded, skipping");
                         }
                     }
                     if (Settings.currentSpell2[1] == "0")
@@ -288,13 +288,12 @@ namespace Leauge_Auto_Accept
                     }
                     else
                     {
-                        var spell = Data.spellsSorted
-                            .First(s => s.id == Settings.currentSpell2[1]);
+                        var spell = Data.spellsSorted.FirstOrDefault(s => s.id == Settings.currentSpell2[1]);
 
-                        if (!spell.gameModes.Contains(gameMode))
+                        if (spell == null || !spell.gameModes.Contains(gameMode))
                         {
                             pickedSpell2 = true;
-                            Log.Debug("Spell 2 no available for current gamemode, skipping");
+                            Log.Debug("Spell 2 not available for current gamemode or not loaded, skipping");
                         }
                     }
                     if (!pickedSpell1)
@@ -328,15 +327,19 @@ namespace Leauge_Auto_Accept
         {
             // Check lobby endpoint for position preferences
             var lobbySessionResp = LCU.clientRequest<LCUTypes.LolLobbyV2Lobby>("GET", "lol-lobby/v2/lobby");
-            var lobbySession = lobbySessionResp.Data;
 
-            if (lobbySessionResp.IsSuccessful)
+            if (lobbySessionResp.IsSuccessful && lobbySessionResp.Data != null)
             {
+                var lobbySession = lobbySessionResp.Data;
                 string firstPositionPreference = lobbySession.LocalMember.FirstPositionPreference;
                 string secondPositionPreference = lobbySession.LocalMember.SecondPositionPreference;
 
                 //find current player within MyTeam array
-                var player = currentChampSelect.MyTeam.Single(x => x.CellId == localPlayerCellId);
+                var player = currentChampSelect.MyTeam.FirstOrDefault(x => x.CellId == localPlayerCellId);
+                if (player == null)
+                {
+                    return true;
+                }
 
                 if (string.Compare(firstPositionPreference, player.AssignedPosition, true) == 0) return true;
                 if (string.Compare(secondPositionPreference, player.AssignedPosition, true) == 0) return false;
@@ -350,9 +353,12 @@ namespace Leauge_Auto_Accept
         {
             var conversationsResp = LCU.clientRequest<LCUTypes.LolChatConversationsV1[]>("GET", "lol-chat/v1/conversations", "");
 
-            if (conversationsResp.Content.Contains(chatId))
+            if (!string.IsNullOrEmpty(chatId) && conversationsResp.Content?.Contains(chatId) == true)
             {
-                Data.loadPlayerChatId();
+                if (!Data.loadPlayerChatId())
+                {
+                    return;
+                }
 
                 long currentTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
 
@@ -405,16 +411,16 @@ namespace Leauge_Auto_Accept
         internal static void handleChampSelectActions(LCUTypes.LolChampSelectSessionV1 currentChampSelect, int localPlayerCellId)
         {
             // This logic skips modes that aren't draft
-            if (currentChampSelect.Actions.Count == 0) return;
+            if (currentChampSelect.Actions == null || currentChampSelect.Actions.Count == 0) return;
 
             var actionsFlat = currentChampSelect.Actions.SelectMany(list => list.AsArray()); //flatten the weird two dimensional array
 
-            foreach (var act in actionsFlat.Where(x => (int)x["actorCellId"] == localPlayerCellId && (bool)x["completed"] == false))
+            foreach (var act in actionsFlat.Where(x => (int?)x["actorCellId"] == localPlayerCellId && (bool?)x["completed"] == false))
             {
                 string actionType = (string)act["type"];
-                int championId = (int)act["championId"];
-                int actId = (int)act["id"];
-                bool ActIsInProgress = (bool)act["isInProgress"];
+                int championId = (int?)act["championId"] ?? 0;
+                int actId = (int?)act["id"] ?? 0;
+                bool ActIsInProgress = (bool?)act["isInProgress"] ?? false;
 
                 switch(actionType)
                 {
@@ -465,9 +471,8 @@ namespace Leauge_Auto_Accept
 
                     foreach (var favIdStr in favorites)
                     {
-                        if (!pickedChamp && isInCrowdFavoriteChamps(favIdStr))
+                        if (!pickedChamp && int.TryParse(favIdStr, out int favId) && isInCrowdFavoriteChamps(favIdStr))
                         {
-                            int favId = int.Parse(favIdStr);
                             hoverChampion(actId, favId, "pick");
                             if (pickedChamp) championId = favId; // assign only if hover succeeded
                         }
@@ -479,17 +484,31 @@ namespace Leauge_Auto_Accept
 
                 if (!pickedChamp && championId != -3)  //TODO: -3 is what???
                 {
-                    int primaryChampId = int.Parse(usePrimaryChamp ? Settings.currentChamp[1] : Settings.secondaryChamp[1]);
-                    int primaryRunesId = int.Parse(usePrimaryChamp ? Settings.currentChampRunes[1] : Settings.secondaryChampRunes[1]);
-                    int backupChampId = int.Parse(usePrimaryChamp ? Settings.currentBackupChamp[1] : Settings.secondaryBackupChamp[1]);
-                    int backupRunesId = int.Parse(usePrimaryChamp ? Settings.currentBackupChampRunes[1] : Settings.secondaryBackupChampRunes[1]);
+                    int primaryChampId = ParseId(usePrimaryChamp ? Settings.currentChamp[1] : Settings.secondaryChamp[1]);
+                    int primaryRunesId = ParseId(usePrimaryChamp ? Settings.currentChampRunes[1] : Settings.secondaryChampRunes[1]);
+                    int backupChampId = ParseId(usePrimaryChamp ? Settings.currentBackupChamp[1] : Settings.secondaryBackupChamp[1]);
+                    int backupRunesId = ParseId(usePrimaryChamp ? Settings.currentBackupChampRunes[1] : Settings.secondaryBackupChampRunes[1]);
+
+                    if (primaryChampId == 0 && !usePrimaryChamp)
+                    {
+                        primaryChampId = ParseId(Settings.currentChamp[1]);
+                        primaryRunesId = ParseId(Settings.currentChampRunes[1]);
+                    }
+                    if (backupChampId == 0 && !usePrimaryChamp)
+                    {
+                        backupChampId = ParseId(Settings.currentBackupChamp[1]);
+                        backupRunesId = ParseId(Settings.currentBackupChampRunes[1]);
+                    }
 
                     // Try first choice based on player is assigned primary or secondary role
-                    hoverChampion(actId, primaryChampId, "pick");
-                    handleRunes(primaryRunesId);
+                    if (primaryChampId > 0)
+                    {
+                        hoverChampion(actId, primaryChampId, "pick");
+                        handleRunes(primaryRunesId);
+                    }
 
                     // If first choice didn't work (pickedChamp is still false), try second choice
-                    if (!pickedChamp)
+                    if (!pickedChamp && backupChampId > 0)
                     {
                         hoverChampion(actId, backupChampId, "pick");
                         handleRunes(backupRunesId);
@@ -545,7 +564,7 @@ namespace Leauge_Auto_Accept
                     {
                         // Ban none if the setting is disabled.
                         bool dontBanCrowd = isArena && Settings.banCrowdFavourite && isInCrowdFavoriteChamps(Settings.currentBan[1]);
-                        hoverChampion(actId, int.Parse(dontBanCrowd ? "0" : Settings.currentBan[1]), "ban");
+                        hoverChampion(actId, ParseId(dontBanCrowd ? "0" : Settings.currentBan[1]), "ban");
                     }
                 }
 
@@ -582,6 +601,11 @@ namespace Leauge_Auto_Accept
 
         private static void handleRunes(int currentRunesId)
         {
+            if (currentRunesId <= 0)
+            {
+                return;
+            }
+
             Log.Info("handleRunes: currentRunesId={0}", currentRunesId);
             var runesResp = LCU.clientRequest("PUT", "lol-perks/v1/currentpage", $"{currentRunesId}");
         }
@@ -630,18 +654,38 @@ namespace Leauge_Auto_Accept
             var swapResp = LCU.clientRequest("GET", "lol-champ-select/v1/ongoing-swap");
             if (swapResp.IsSuccessStatusCode)
             {
+                JsonNode swap;
+                try
+                {
+                    swap = JsonNode.Parse(swapResp.Content);
+                }
+                catch (JsonException ex)
+                {
+                    Log.Debug(ex, "Failed to parse ongoing swap response.");
+                    return;
+                }
+
                 // If the swap was called by local player, return
-                if (swapResp.Content.Contains("initiatedByLocalPlayer\":true"))
+                if ((bool?)swap?["initiatedByLocalPlayer"] == true)
                 {
                     return;
                 }
                 // Get action ID
-                string swapId = swapResp.Content.Split("\"id\":")[1].Split(',')[0];
+                int? swapId = (int?)swap?["id"];
+                if (swapId == null)
+                {
+                    return;
+                }
 
                 // Swap pick order
                 LCU.clientRequest("POST", "lol-champ-select/v1/session/swaps/" + swapId + "/accept");
                 LCU.clientRequest("POST", "lol-champ-select/v1/ongoing-swap/" + swapId + "/clear");
             }
+        }
+
+        private static int ParseId(string value)
+        {
+            return int.TryParse(value, out int result) ? result : 0;
         }
     }
 }

--- a/Leauge Auto Accept/UI.cs
+++ b/Leauge Auto Accept/UI.cs
@@ -658,7 +658,12 @@ namespace Leauge_Auto_Accept
 
             Console.Clear();
 
-            Data.loadChampionsList();
+            if (!Data.loadChampionsList())
+            {
+                Print.printCentered("Failed to load champions from League.", SizeHandler.HeightCenter - 1);
+                Print.printCentered("Press Escape to return.");
+                return;
+            }
 
             displayChamps();
             updateCurrentFilter();
@@ -752,7 +757,12 @@ namespace Leauge_Auto_Accept
 
             Console.Clear();
 
-            Data.loadRunesList();
+            if (!Data.loadRunesList())
+            {
+                Print.printCentered("Failed to load rune pages from League.", SizeHandler.HeightCenter - 1);
+                Print.printCentered("Press Escape to return.");
+                return;
+            }
 
             displayRunes();
             updateCurrentFilter();
@@ -835,7 +845,12 @@ namespace Leauge_Auto_Accept
 
             Console.Clear();
 
-            Data.loadSpellsList();
+            if (!Data.loadSpellsList())
+            {
+                Print.printCentered("Failed to load summoner spells from League.", SizeHandler.HeightCenter - 1);
+                Print.printCentered("Press Escape to return.");
+                return;
+            }
 
             displaySpells();
             updateCurrentFilter();

--- a/Leauge Auto Accept/Updater.cs
+++ b/Leauge Auto Accept/Updater.cs
@@ -35,14 +35,14 @@ namespace Leauge_Auto_Accept
             Console.Clear();
             Print.printCentered("Checking for an update...", SizeHandler.HeightCenter);
             var releaseResp = webRequest("https://api.github.com/repos/sweetriverfish/LeagueAutoAccept/releases/latest");
-            if (releaseResp.IsSuccessStatusCode == false)
+            if (releaseResp == null || releaseResp.IsSuccessStatusCode == false)
             {
                 // Network error
                 Console.Clear();
                 Print.printCentered("Failed to check for an update.", SizeHandler.HeightCenter - 1);
                 Print.printCentered("You can disable this check in the settings.");
-                Print.printCentered("App will launch in 5 seconds.");
-                Thread.Sleep(5000);
+                Print.printCentered("App will launch shortly.");
+                Thread.Sleep(1500);
             }
             else
             {
@@ -99,13 +99,18 @@ namespace Leauge_Auto_Accept
                 }))
                 {
 
+                    var request = new RestRequest(url)
+                    {
+                        Timeout = TimeSpan.FromMilliseconds(5000)
+                    };
+
                     // Get the response
-                    resp = client.ExecuteGet(new RestRequest(url));
+                    resp = client.ExecuteGet(request);
                     resp.ThrowIfError();
                     return resp;
                 }
             }
-            catch(Exception ex)
+            catch
             {
                 return resp;
             }

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
- Added a repo-level `NuGet.config` so the project restores and builds reliably with `dotnet build`.
- Improved League Client / LCU startup handling to avoid getting stuck on `Initializing...`.
- Added request timeouts and limited retries for LCU calls.
- Made champion, rune, spell, summoner, and chat data loading safer when LCU returns empty, delayed, or failed responses.
- Improved fallback behavior during champion select when spell data, role data, rune IDs, or secondary champion settings are missing.
- Replaced fragile pick-order swap string parsing with JSON parsing.
- Made the update check faster and safer when GitHub is slow or unreachable.
- Kept the existing auto accept, pick, ban, rune, spell, and chat behavior unchanged.
- Target framework remains `net9.0`.